### PR TITLE
Ensure Workplan and Budget doc sections use landscape layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -888,7 +888,7 @@ def build_logframe_docx():
 
     # ==== WORKPLAN – Activities (table) ====
     from docx.shared import Cm
-    _new_section("WORKPLAN")
+    _new_landscape_section("WORKPLAN")
 
     # Build tidy DF exactly as in the app
     df_wp = _workplan_df()  # includes Activity/Output labels, Owner, Start, End
@@ -999,7 +999,7 @@ def build_logframe_docx():
         pass
 
     # ===== BUDGET =====
-    _ensure_portrait_section("BUDGET")
+    _new_landscape_section("BUDGET")
 
     # Detailed budget table: Activity | Line Item | Category | Sub-Category | Unit | Unit Cost (USD) | Quantity | Total (USD)
     bt = doc.add_table(rows=1, cols=8)


### PR DESCRIPTION
## Summary
- switch the Workplan activities table page to use `_new_landscape_section` for landscape orientation
- generate the Budget page with `_new_landscape_section` so it matches the required landscape layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3614b5cc0832285599333896ca36a