### PR TITLE
Fix landscape section orientation reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -666,8 +666,9 @@ def build_logframe_docx():
     def _new_landscape_section(title):
         sec = doc.add_section(WD_SECTION_START.NEW_PAGE)
         sec.orientation = WD_ORIENT.LANDSCAPE
-        # swap page size
-        sec.page_width, sec.page_height = sec.page_height, sec.page_width
+        # Only swap dimensions if the section is still portrait-sized.
+        if sec.page_width < sec.page_height:
+            sec.page_width, sec.page_height = sec.page_height, sec.page_width
         _h1(title)
         return sec
 


### PR DESCRIPTION
## Summary
- prevent `_new_landscape_section` from swapping dimensions when the new section already has landscape dimensions

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e37bfcb5788322a64a2a074e79e576